### PR TITLE
Add plugin URL

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -4,6 +4,7 @@
 # about: Show users how many characters are required before posting
 # version: 0.1
 # authors: Robin Ward
+# url: https://github.com/discourse/discourse-characters-required
 
 enabled_site_setting :characters_required_enabled
 


### PR DESCRIPTION
This commit adds the plugin's url to plugin.rb and enables a link back to this GitHub repository from the plugin admin page in Discourse as a result